### PR TITLE
Add CSV reading and URL support for JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
 <img src="icon.png" width="125" height="125" align="right" />
 
-### lazylines 
+### lazylines
 
-This project contains a minimal method-chained API to deal with `.jsonl` files. 
+This project contains a minimal method-chained API to deal with `.jsonl` and `.csv` files.
 The API is inspired by [dplyr](https://dplyr.tidyverse.org/) and is designed to be lazy.
-Everything is a generator until you call `.collect()`. 
+Everything is a generator until you call `.collect()`.
+
+## Features
+
+- Read `.jsonl` files from local paths or URLs
+- Read `.csv` files from local paths or URLs
+- Lazy evaluation - data is only loaded as needed
+- Method chaining for data transformation
+- Support for custom delimiters and field names
+
+## Quick Examples
+
+```python
+from lazylines import read_jsonl, read_csv
+
+# Read JSONL from URL
+pokemon = read_jsonl("https://calmcode.io/static/data/pokemon.jsonl")
+for p in pokemon.head(5):
+    print(p['name'])
+
+# Read CSV from local file
+data = read_csv("data.csv")
+
+# Read CSV from URL with head() for row limit
+iris = read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv").head(100)
+
+# Chain operations
+results = (
+    read_csv("data.csv")
+    .mutate(new_col=lambda d: d["age"] * 2)
+    .keep(lambda d: d["age"] > 25)
+    .select("name", "new_col")
+    .collect()
+)
+```
 
 The best way to explore is to check the docs on GitHub pages. 

--- a/lazylines/__init__.py
+++ b/lazylines/__init__.py
@@ -40,6 +40,7 @@ def read_jsonl(path: str | Path) -> LazyLines:
             with urllib.request.urlopen(path_str) as resp:  # nosec
                 for line in resp:
                     yield srsly.json_loads(line.decode().strip())
+
         return LazyLines(url_gen())
     else:
         # Handle local file

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from lazylines import read_csv, read_jsonl
+
+
+def test_read_csv_local(tmp_path):
+    """Test reading local CSV files with various options."""
+    # Create test CSV
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text("name,age,city\nAlice,30,New York\nBob,25,LA\n")
+
+    # Basic read
+    result = read_csv(csv_file).collect()
+    assert len(result) == 2
+    assert result[0] == {"name": "Alice", "age": "30", "city": "New York"}
+
+    # With head() for row limit
+    result = read_csv(csv_file).head(1).collect()
+    assert len(result) == 1
+
+    # Custom delimiter
+    tsv_file = tmp_path / "test.tsv"
+    tsv_file.write_text("name\tage\nAlice\t30\n")
+    result = read_csv(tsv_file, delimiter="\t").collect()
+    assert result[0] == {"name": "Alice", "age": "30"}
+
+    # Custom fieldnames (first row becomes data)
+    result = read_csv(csv_file, fieldnames=["col1", "col2", "col3"]).collect()
+    assert len(result) == 3
+    assert result[0] == {"col1": "name", "col2": "age", "col3": "city"}
+
+    # Method chaining
+    result = (
+        read_csv(csv_file)
+        .mutate(age_plus_10=lambda d: str(int(d["age"]) + 10))
+        .select("name", "age_plus_10")
+        .collect()
+    )
+    assert result[0] == {"name": "Alice", "age_plus_10": "40"}
+
+
+def test_read_jsonl_local():
+    """Test reading local JSONL file."""
+    jsonl_path = Path(__file__).parent / "pokemon.jsonl"
+    result = read_jsonl(jsonl_path).head(3).collect()
+    assert len(result) == 3

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -30,12 +30,7 @@ def test_read_csv_local(tmp_path):
     assert result[0] == {"col1": "name", "col2": "age", "col3": "city"}
 
     # Method chaining
-    result = (
-        read_csv(csv_file)
-        .mutate(age_plus_10=lambda d: str(int(d["age"]) + 10))
-        .select("name", "age_plus_10")
-        .collect()
-    )
+    result = read_csv(csv_file).mutate(age_plus_10=lambda d: str(int(d["age"]) + 10)).select("name", "age_plus_10").collect()
     assert result[0] == {"name": "Alice", "age_plus_10": "40"}
 
 


### PR DESCRIPTION
## Summary

- Add `read_csv()` function for local and remote CSV files
- Enhance `read_jsonl()` to support URLs like `https://calmcode.io/static/data/pokemon.jsonl`
- Support custom delimiters and fieldnames
- Minimal test suite with no network dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)